### PR TITLE
fix: escape special characters in log format to prevent parsing errors

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -58,6 +58,7 @@ class RipLogger:
             self.full_name = artist
         else:
             self.full_name = f"{artist} - {name}"
+        self.full_name = self.full_name.replace("<", "<").replace(">", ">")
         self.logger.remove()
         self.logger.add(lambda msg: print_formatted_text(ANSI(msg), end=""), colorize=True,
                         format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>"


### PR DESCRIPTION
Avoid parsing errors when special characters that could be interpreted as HTML tags exist in the album name, e.g. <I°_°I>
#78 
