### PR TITLE
fix: escape special characters in log format to prevent parsing errors

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -38,8 +38,8 @@ class RipLogger:
     metadata: "SongMetadata"
 
     def __init__(self, _type: str, item_id: str):
-        self.item_type = _type
-        self.item_id = item_id
+        self.item_type = _type.replace("<", r"\<").replace(">", r"\>")
+        self.item_id = item_id.replace("<", r"\<").replace(">", r"\>")
         logger.remove()
         self.logger = copy.deepcopy(logger)
         self.logger.add(lambda msg: print_formatted_text(ANSI(msg), end=""), colorize=True,

--- a/src/logger.py
+++ b/src/logger.py
@@ -58,11 +58,13 @@ class RipLogger:
             self.full_name = artist
         else:
             self.full_name = f"{artist} - {name}"
+
+        escaped_full_name = self.full_name.replace("<", r"\<").replace(">", r"\>")
         self.logger.remove()
         self.logger.add(lambda msg: print_formatted_text(ANSI(msg), end=""), colorize=True,
                         format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>"
                                + f" | <b>{self.item_type.upper()}</b>"
-                               + f" | <b>{self.full_name}</b>"
+                               + f" | <b>{escaped_full_name}</b>"
                                + " | <level>{level}</level>"
                                + " - <level>{message}</level>",
                         level="INFO")


### PR DESCRIPTION
Avoid parsing errors when special characters that could be interpreted as HTML tags exist in the album name, e.g. <I°_°I>
#78