### PR TITLE
replacement类型的翻译直接替换原歌词行

### DIFF
--- a/android-deploy.md
+++ b/android-deploy.md
@@ -15,7 +15,7 @@ apt update && apt install pipx git -y && pipx install poetry && pipx ensurepath 
 git clone https://github.com/WorldObservationLog/AppleMusicDecrypt
 cd AppleMusicDecrypt
 bash ./tools/install-deps.sh
-poetry install
+poetry env use /usr/bin/python3 && poetry install
 cp config.example.toml config.toml
 nano config.toml
 ```

--- a/src/utils.py
+++ b/src/utils.py
@@ -124,8 +124,11 @@ def ttml_convent(ttml: str) -> str:
             lrc_lines.append(
                 f"[{str(m + h * 60).rjust(2, '0')}:{str(s).rjust(2, '0')}.{str(int(ms / 10)).rjust(2, '0')}]{lyric.text}")
             if "translation" in it(Config).download.lyricsExtra and b.tt.head.metadata.iTunesMetadata.translation:
+                trans_type = b.tt.head.metadata.iTunesMetadata.translation.get("type")
                 for translation in b.tt.head.metadata.iTunesMetadata.translation.children:
                     if lyric.get("itunes:key") == translation.get("for"):
+                        if trans_type == "replacement":
+                            del lrc_lines[-1]
                         lrc_lines.append(
                             f"[{str(m + h * 60).rjust(2, '0')}:{str(s).rjust(2, '0')}.{str(int(ms / 10)).rjust(2, '0')}]{translation.text}")
             if "pronunciation" in it(Config).download.lyricsExtra and b.tt.head.metadata.iTunesMetadata.transliteration:


### PR DESCRIPTION
replacement类型的翻译一般为繁简翻译，可直接替换，

官方安卓端逻辑为替换
官方web端逻辑为保留

相关举例
https://music.apple.com/cn/song/%E5%8F%AF%E7%88%B1%E5%A5%B3%E4%BA%BA/535791109