### PR TITLE
Fix qemu-system-x86_64 dependency issue

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -246,7 +246,7 @@ def convent_mac_timestamp_to_datetime(timestamp: int):
 def check_dep():
     deps = ["ffmpeg", "gpac", "MP4Box", "mp4edit", "mp4extract", "mp4decrypt"]
     if it(Config).localInstance.enable:
-        deps.append("qemu-system-x86_64 --version")
+        deps.append("qemu-system-x86_64")
     for dep in deps:
         try:
             subprocess.run(dep, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
fixes `ERROR - Dependence qemu-system-x86_64 --version was not installed!` despite `qemu-system-x86_64` having installed